### PR TITLE
BB-1050: Add pairs to Bitfinex

### DIFF
--- a/src/BitOasis/Bitfinex/Constant/Symbol.php
+++ b/src/BitOasis/Bitfinex/Constant/Symbol.php
@@ -27,6 +27,15 @@ final class Symbol {
 	const TBSVBTC = 'tBSVBTC';
 	const TEOSUSD = 'tEOSUSD';
 	const TEOSBTC = 'tEOSBTC';
+	const TEOSETH = 'tEOSETH';
+	const TOMGUSD = 'tOMGUSD';
+	const TOMGBTC = 'tOMGBTC';
+	const TZRXUSD = 'tZRXUSD';
+	const TZRXBTC = 'tZRXBTC';
+	const TBATUSD = 'tBATUSD';
+	const TBATBTC = 'tBATBTC';
+	const TALGUSD = 'tALGUSD';
+	const TALGBTC = 'tALGBTC';
 
 	public static function isTrading(string $symbol): bool {
 	    return $symbol !== '' && $symbol[0] === 't';


### PR DESCRIPTION
added trading symbol consts for USD and BTC pairs of tokens OMG, ZRX, BAT, ALG and EOS-ETH as well

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bit-oasis/bitfinex-api/8)
<!-- Reviewable:end -->
